### PR TITLE
Fix error in spanish-noun-feminine

### DIFF
--- a/templates.py
+++ b/templates.py
@@ -3913,7 +3913,7 @@ templates = collections.OrderedDict([
                             'type': 'wikibase-entityid',
                             'value': {
                                 'entity-type': 'item',
-                                'id': 'Q499327',
+                                'id': 'Q1775415',
                             },
                         },
                     },


### PR DESCRIPTION
`spanish-noun-feminine` should be feminine (Q1775415), not masculine (Q499327). See <https://www.wikidata.org/wiki/Wikidata:Wikidata_Lexeme_Forms/Spanish#Sustantivo_femenino_en_espa%C3%B1ol>.