### PR TITLE
If there are no UI translations for a template language, fall back to English

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,9 +187,7 @@ def message_with_language(message_code, language_code=None):
     if language_code == 'bn-x-Q6747180':
         # Manbhumi reuses the standard Bengali messages
         language_code = 'bn'
-    if language_code not in translations:
-        language_code = 'en'
-    if message_code not in translations[language_code]:
+    if message_code not in translations.get(language_code, {}):
         language_code = 'en'
     text = translations[language_code][message_code]
     return flask.Markup(text), language_code

--- a/app.py
+++ b/app.py
@@ -187,6 +187,8 @@ def message_with_language(message_code, language_code=None):
     if language_code == 'bn-x-Q6747180':
         # Manbhumi reuses the standard Bengali messages
         language_code = 'bn'
+    if language_code not in translations:
+        language_code = 'en'
     if message_code not in translations[language_code]:
         language_code = 'en'
     text = translations[language_code][message_code]


### PR DESCRIPTION
Right now it crashes if there's no entry in the translations file for the language, which means you have to add an entry to the translations file before you can work on a template. Adding a key with no translations fixes it and causes all the messages to fall back to English, but it would be nicer to handle it more gracefully and automatically fall back to English when there's no entry.

The tests still check whether the language is in the translations file so that adding the translations doesn't get forgotten completely.