### PR TITLE
Handle errors better when bulk mode parsing fails

### DIFF
--- a/app.py
+++ b/app.py
@@ -280,7 +280,16 @@ def process_template_bulk(template_name):
         csrf_token_matches(flask.request.form)):
 
         form_data = flask.request.form
-        lexemes = parse_lexemes(form_data.get('lexemes'), template)
+        try:
+            lexemes = parse_lexemes(form_data.get('lexemes'), template)
+        except ValueError as parse_error:
+            return flask.render_template(
+                'bulk.html',
+                template=template,
+                value=form_data.get('lexemes'),
+                parse_error=parse_error
+        )
+
         results = []
 
         for lexeme in lexemes:

--- a/app.py
+++ b/app.py
@@ -287,8 +287,8 @@ def process_template_bulk(template_name):
                 'bulk.html',
                 template=template,
                 value=form_data.get('lexemes'),
-                parse_error=parse_error
-        )
+                parse_error=parse_error,
+            )
 
         results = []
 

--- a/templates/bulk.html
+++ b/templates/bulk.html
@@ -11,6 +11,11 @@
     {{ message( 'csrf_warning' ) }}
   </div>
   {% endif %}
+  {% if parse_error %}
+  <div class="alert alert-warning">
+     {{ message( 'bulk_parse_error' ) }}
+  </div>
+  {% endif %}
   <form method="post" autocapitalize="off">
     <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
     <div class="form-group">

--- a/templates/bulk.html
+++ b/templates/bulk.html
@@ -13,7 +13,7 @@
   {% endif %}
   {% if parse_error %}
   <div class="alert alert-warning">
-     {{ parse_error }}
+    {{ parse_error }}
   </div>
   {% endif %}
   <form method="post" autocapitalize="off">

--- a/templates/bulk.html
+++ b/templates/bulk.html
@@ -13,7 +13,7 @@
   {% endif %}
   {% if parse_error %}
   <div class="alert alert-warning">
-     {{ message( 'bulk_parse_error' ) }}
+     {{ parse_error }}
   </div>
   {% endif %}
   <form method="post" autocapitalize="off">

--- a/translations.py
+++ b/translations.py
@@ -20,6 +20,7 @@ translations = {
         'bulk_heading': 'bulk mode',
         'bulk_format_help': 'format help',
         'bulk_not_allowed': 'You are not allowed to use bulk mode. Sorry.',
+        'bulk_parse_error': 'Wrong number of columns',
         'edit_button': 'Edit',
         'edit_link': 'edit',
         'edit_general': 'You are in “edit” mode. Changing the values below will edit, add or remove forms of the target lexeme.',

--- a/translations.py
+++ b/translations.py
@@ -20,7 +20,6 @@ translations = {
         'bulk_heading': 'bulk mode',
         'bulk_format_help': 'format help',
         'bulk_not_allowed': 'You are not allowed to use bulk mode. Sorry.',
-        'bulk_parse_error': 'Wrong number of columns',
         'edit_button': 'Edit',
         'edit_link': 'edit',
         'edit_general': 'You are in “edit” mode. Changing the values below will edit, add or remove forms of the target lexeme.',


### PR DESCRIPTION
Right now when using bulk mode, if your data has the wrong number of columns, it crashes. This makes it return to the form (preserving your input) and display the error message instead.

(For now the error message hasn't been made translatable - it should presumably be revisited once the translations have been moved to Translatewiki)