### PR TITLE
Prevent double submit of forms in JS

### DIFF
--- a/static/preventDoubleSubmit.js
+++ b/static/preventDoubleSubmit.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function() {
+    'use strict';
+
+    for (const form of document.forms) {
+        let lastSubmit = null;
+        form.addEventListener('submit', (e) => {
+            if (lastSubmit && (Date.now() - lastSubmit) < 5000) {
+                e.preventDefault();
+            } else {
+                lastSubmit = Date.now();
+            }
+        });
+    }
+});

--- a/templates/bulk.html
+++ b/templates/bulk.html
@@ -1,4 +1,8 @@
 {% extends "base.html" %}
+{% block head %}
+{{ super() }}
+<script src="{{ url_for('static', filename='preventDoubleSubmit.js') }}"></script>
+{% endblock %}
 {% block main_tag_attributes %}{{ super() }} lang="{{ template.language_code }}" dir="{{ template.language_code | text_direction }}"{% endblock main_tag_attributes %}
 {% block main %}
   <h1>{{ template.label }}</h1>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -21,6 +21,7 @@
 {% block head %}
 {{ super() }}
 <script src="{{ url_for('static', filename='edit.js') }}"></script>
+<script src="{{ url_for('static', filename='preventDoubleSubmit.js') }}"></script>
 <link rel="stylesheet" href="{{ url_for('static', filename='template.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='edit.css') }}">
 {% endblock %}

--- a/templates/template.html
+++ b/templates/template.html
@@ -4,6 +4,7 @@
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/lodash.js/4.17.10/lodash.min.js"></script>
 <script src="{{ url_for('static', filename='findDuplicates.js') }}"></script>
 <script src="{{ url_for('static', filename='alertPartialForms.js') }}"></script>
+<script src="{{ url_for('static', filename='preventDoubleSubmit.js') }}"></script>
 <link rel="stylesheet" href="{{ url_for('static', filename='template.css') }}">
 {% endblock %}
 {% block main_tag_attributes %}{{ super() }} lang="{{ template.language_code }}" dir="{{ template.language_code | text_direction }}" data-template='{{ template | tojson }}'{% endblock main_tag_attributes %}


### PR DESCRIPTION
Disable submits of a form for five seconds after it has been submitted the first time. This should hopefully prevent users from accidentally creating the same lexeme more than once. (I don’t think we can guard against this server-side.) The prevention is not permanent so that users can resubmit the form e.g. if their network connection died or they used the “back” button.