### PR TITLE
Add Portuguese noun templates, update verb template

### DIFF
--- a/templates.py
+++ b/templates.py
@@ -7123,8 +7123,8 @@ templates = collections.OrderedDict([
     }),
 
     ('portuguese-verb', {
-        '@attribution': {'users': ['Carybe', 'Joalpe', 'Waldir'], 'title': 'Wikidata:Wikidata Lexeme Forms/Portuguese'},
-        'label': 'verbo em Português',
+        '@attribution': {'users': ['Carybe', 'EnaldoSS', 'Joalpe', 'Waldir'], 'title': 'Wikidata:Wikidata Lexeme Forms/Portuguese'},
+        'label': 'verbo em português',
         'language_item_id': 'Q5146',
         'language_code': 'pt',
         'lexical_category_item_id': 'Q24905',
@@ -7427,27 +7427,27 @@ templates = collections.OrderedDict([
             {
                 'section_break': True,
                 'label': 'Segunda Pessoa do Singular do Modo Imperativo Afirmativo',
-                'example': '[Canta] tu agora que há tempo.',
+                'example': '[canta] tu agora que há tempo.',
                 'grammatical_features_item_ids': ['Q51929049', 'Q110786', 'Q22716'],
             },
             {
                 'label': 'Terceira Pessoa do Singular do Modo Imperativo Afirmativo',
-                'example': '[Canta] você agora que há tempo.',
+                'example': '[canta] você agora que há tempo.',
                 'grammatical_features_item_ids': ['Q51929074', 'Q110786', 'Q22716'],
             },
             {
                 'label': 'Primeira Pessoa do Plural do Modo Imperativo Afirmativo',
-                'example': '[Cantemos] nós agora que há tempo.',
+                'example': '[cantemos] nós agora que há tempo.',
                 'grammatical_features_item_ids': ['Q21714344', 'Q146786', 'Q22716'],
             },
             {
                 'label': 'Segunda Pessoa do Plural do Modo Imperativo Afirmativo',
-                'example': '[Cantai] vós agora que há tempo.',
+                'example': '[cantai] vós agora que há tempo.',
                 'grammatical_features_item_ids': ['Q51929049', 'Q146786', 'Q22716'],
             },
             {
                 'label': 'Terceira Pessoa do Plural do Modo Imperativo Afirmativo',
-                'example': '[Cantem] vocês agora que há tempo.',
+                'example': '[cantem] vocês agora que há tempo.',
                 'grammatical_features_item_ids': ['Q51929074', 'Q146786', 'Q22716'],
             },
             {

--- a/templates.py
+++ b/templates.py
@@ -7042,6 +7042,86 @@ templates = collections.OrderedDict([
         ],
     }),
 
+    ('portuguese-noun-masculine', {
+        '@attribution': {'users': ['EnaldoSS'], 'title': 'Wikidata:Wikidata Lexeme Forms/Portuguese'},
+        'label': 'substantivo masculino em português',
+        'language_item_id': 'Q5146',
+        'language_code': 'pt',
+        'lexical_category_item_id': 'Q1084',
+        'forms': [
+            {
+                'label': 'singular',
+                'example': 'Este é um [livro].',
+                'grammatical_features_item_ids': ['Q110786'],
+            },
+            {
+                'label': 'plural',
+                'example': 'Estes são alguns [livros].',
+                'grammatical_features_item_ids': ['Q146786'],
+            },
+        ],
+        'statements': {
+            'P5185': [
+                {
+                    'mainsnak': {
+                        'snaktype': 'value',
+                        'property': 'P5185',
+                        'datatype': 'wikibase-item',
+                        'datavalue': {
+                            'type': 'wikibase-entityid',
+                            'value': {
+                                'entity-type': 'item',
+                                'id': 'Q499327',
+                            },
+                        },
+                    },
+                    'type': 'statement',
+                    'rank': 'normal',
+                }
+            ],
+        },
+    }),
+
+    ('portuguese-noun-feminine', {
+        '@attribution': {'users': ['EnaldoSS'], 'title': 'Wikidata:Wikidata Lexeme Forms/Portuguese'},
+        'label': 'substantivo feminino em português',
+        'language_item_id': 'Q5146',
+        'language_code': 'pt',
+        'lexical_category_item_id': 'Q1084',
+        'forms': [
+            {
+                'label': 'singular',
+                'example': 'Esta é uma [maçã].',
+                'grammatical_features_item_ids': ['Q110786'],
+            },
+            {
+                'label': 'plural',
+                'example': 'Estas são umas [maçãs].',
+                'grammatical_features_item_ids': ['Q146786'],
+            },
+        ],
+        'statements': {
+            'P5185': [
+                {
+                    'mainsnak': {
+                        'snaktype': 'value',
+                        'property': 'P5185',
+                        'datatype': 'wikibase-item',
+                        'datavalue': {
+                            'type': 'wikibase-entityid',
+                            'value': {
+                                'entity-type': 'item',
+                                'id': 'Q1775415',
+                            },
+                        },
+                    },
+                    'type': 'statement',
+                    'rank': 'normal',
+                }
+            ],
+        },
+    }),
+
     ('portuguese-verb', {
         '@attribution': {'users': ['Carybe', 'Joalpe', 'Waldir'], 'title': 'Wikidata:Wikidata Lexeme Forms/Portuguese'},
         'label': 'verbo em Português',


### PR DESCRIPTION
This adds the noun templates from https://www.wikidata.org/wiki/Wikidata:Wikidata_Lexeme_Forms/Portuguese and updates the capitalisation for the verb template.