### PR TITLE
Add language code as element id

### DIFF
--- a/app.py
+++ b/app.py
@@ -194,6 +194,8 @@ def language_autonym_with_code(language_code):
         return code_zxx
     return (flask.Markup(r'<span lang="') +
             flask.Markup.escape(language_code) +
+            flask.Markup(r'" id="') +
+            flask.Markup.escape(language_code) +
             flask.Markup(r'" dir="') +
             flask.Markup.escape(text_direction(language_code)) +
             flask.Markup(r'">') +

--- a/test_app.py
+++ b/test_app.py
@@ -75,11 +75,11 @@ def test_csrf_token_load():
 
 def test_template_group():
     group = lexeme_forms.template_group({'language_code': 'de'})
-    assert group == '<span lang="de" dir="ltr">Deutsch (<span lang=zxx>de</span>)</span>'
+    assert group == '<span lang="de" id="de" dir="ltr">Deutsch (<span lang=zxx>de</span>)</span>'
 
 def test_template_group_test():
     group = lexeme_forms.template_group({'language_code': 'de', 'test': True})
-    assert group == '<span lang="de" dir="ltr">Deutsch (<span lang=zxx>de</span>)</span>, test.wikidata.org'
+    assert group == '<span lang="de" id="de" dir="ltr">Deutsch (<span lang=zxx>de</span>)</span>, test.wikidata.org'
 
 @pytest.mark.parametrize('template_name', templates.keys())
 @pytest.mark.parametrize('number', range(-1, 5))


### PR DESCRIPTION
Add language code as id for language names in the list of languages, so that you can link directly to a language on the tool main page.