### PR TITLE
Add target hash URL parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -281,7 +281,8 @@ def process_template_advanced(template_name, advanced=True):
 
         if 'oauth' in app.config:
             lexeme_id, lexeme_uri = submit_lexeme(template, lexeme_data, summary)
-            return flask.redirect(lexeme_uri, code=303)
+            target = add_hash_to_uri(lexeme_uri, form_data.get('target_hash'))
+            return flask.redirect(target, code=303)
         else:
             print(summary)
             return flask.jsonify(lexeme_data)
@@ -725,6 +726,8 @@ def add_form_data_to_template(form_data, template, overwrite=True):
         template['lexeme_id'] = form_data['lexeme_id']
     if 'generated_via' in form_data:
         template['generated_via'] = form_data['generated_via']
+    if 'target_hash' in form_data:
+        template['target_hash'] = form_data['target_hash']
     return template
 
 def if_needs_csrf_redirect(template, advanced, form_data):
@@ -932,6 +935,12 @@ def submit_lexeme(template, lexeme_data, summary):
 
     lexeme_uri = host + '/entity/' + lexeme_id
     return lexeme_id, lexeme_uri
+
+def add_hash_to_uri(uri, hash):
+    assert '#' not in uri
+    if hash is not None:
+        uri += '#' + hash
+    return uri
 
 def add_labels_to_lexeme_forms_grammatical_features(session, language, lexeme_forms):
     grammatical_features_item_ids = set()

--- a/app.py
+++ b/app.py
@@ -475,7 +475,8 @@ def process_template_edit(template_name, lexeme_id):
 
         if 'oauth' in app.config:
             lexeme_id, lexeme_uri = submit_lexeme(template, lexeme_data, summary)
-            return flask.redirect(lexeme_uri, code=303)
+            target = add_hash_to_uri(lexeme_uri, form_data.get('target_hash'))
+            return flask.redirect(target, code=303)
         else:
             print(summary)
             return flask.jsonify(lexeme_data)

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -99,6 +99,9 @@
         <div class="section-spacer"></div>
       </div>
     </dl>
+    {% if template.target_hash %}
+    <input name="target_hash" type="hidden" value="{{ template.target_hash }}">
+    {% endif %}
     <button class="btn btn-primary"{% if readonly %} disabled title="{{ message_with_kwargs( 'login_hint', url=url_for( 'login' ) ) | striptags }}" {% endif %}>{{ message( 'edit_button' ) }}</button>
   </form>
 {% endblock main %}

--- a/templates/template.html
+++ b/templates/template.html
@@ -73,6 +73,9 @@
       </label>
     </div>
     {% endif %}
+    {% if template.target_hash %}
+    <input name="target_hash" type="hidden" value="{{ template.target_hash }}">
+    {% endif %}
     {% if duplicates %}
     {{ render_no_duplicate(g.interface_language_code) | safe }}
     {% endif %}

--- a/test_app.py
+++ b/test_app.py
@@ -350,6 +350,18 @@ def test_add_form_data_to_template_lexeme_id():
     new_template = lexeme_forms.add_form_data_to_template(form_data, template)
     assert new_template['lexeme_id'] == 'L123'
 
+def test_add_form_data_to_template_generated_via():
+    form_data = werkzeug.datastructures.ImmutableMultiDict([('generated_via', 'something')])
+    template = {'forms': []}
+    new_template = lexeme_forms.add_form_data_to_template(form_data, template)
+    assert new_template['generated_via'] == 'something'
+
+def test_add_form_data_to_template_target_hash():
+    form_data = werkzeug.datastructures.ImmutableMultiDict([('target_hash', 'something')])
+    template = {'forms': []}
+    new_template = lexeme_forms.add_form_data_to_template(form_data, template)
+    assert new_template['target_hash'] == 'something'
+
 def test_add_form_data_to_template_no_template_modification():
     form_data = werkzeug.datastructures.ImmutableMultiDict([('lexeme_id', 'L123')])
     template = {'forms': []}
@@ -755,6 +767,13 @@ def test_build_summary_generated_via():
     with lexeme_forms.app.test_request_context(base_url='https://lexeme-forms.toolforge.org/'):
         summary = lexeme_forms.build_summary(template, form_data)
     assert summary == '[[toolforge:lexeme-forms/template/foo/|foo]], generated via [[toolforge:other/bar|other tool, bar]]'
+
+@pytest.mark.parametrize('uri, hash, expected', [
+    ('https://example.com/', None, 'https://example.com/'),
+    ('https://example.com/', 'abc', 'https://example.com/#abc'),
+])
+def test_add_hash_to_uri(uri, hash, expected):
+    assert lexeme_forms.add_hash_to_uri(uri, hash) == expected
 
 def test_get_all_templates_api():
     with lexeme_forms.app.test_client() as client:


### PR DESCRIPTION
This adds a `target_hash` URL parameter to regular, advanced, and edit mode, which users can use to pass arbitrary information from the tool to the created (or edited) lexeme, where that information can then be picked up by user scripts.

Bulk mode is left alone for now, since it’s not clear if there should be a single URL parameter for all lexemes, or a possibility to customize it for each line in the input.

Fixes #54.