### PR TITLE
Make the navbar mobile-friendly

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -7,5 +7,5 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const button = document.querySelector('nav .navbar-toggler');
     button.hidden = false;
-    button.addEventListener('click', () => { menu.classList.toggle('show') });
+    button.addEventListener('click', () => { menu.classList.toggle('show'); });
 });

--- a/static/menu.js
+++ b/static/menu.js
@@ -1,0 +1,6 @@
+let menu = document.getElementById("collapsible-menu");
+menu.classList = "collapse navbar-collapse";
+
+let button = document.querySelector("nav .navbar-toggler");
+button.toggleAttribute("hidden");
+button.addEventListener("click", () => { menu.classList.toggle("show") });

--- a/static/menu.js
+++ b/static/menu.js
@@ -2,7 +2,8 @@ document.addEventListener('DOMContentLoaded', function() {
     'use strict';
 
     const menu = document.getElementById('collapsible-menu');
-    menu.classList = 'collapse navbar-collapse';
+    menu.classList.remove('nojs');
+    menu.classList.add('collapse', 'navbar-collapse');
 
     const button = document.querySelector('nav .navbar-toggler');
     button.hidden = false;

--- a/static/menu.js
+++ b/static/menu.js
@@ -1,6 +1,10 @@
-let menu = document.getElementById("collapsible-menu");
-menu.classList = "collapse navbar-collapse";
+document.addEventListener('DOMContentLoaded', function() {
+    'use strict';
 
-let button = document.querySelector("nav .navbar-toggler");
-button.toggleAttribute("hidden");
-button.addEventListener("click", () => { menu.classList.toggle("show") });
+    const menu = document.getElementById('collapsible-menu');
+    menu.classList = 'collapse navbar-collapse';
+
+    const button = document.querySelector('nav .navbar-toggler');
+    button.hidden = false;
+    button.addEventListener('click', () => { menu.classList.toggle('show') });
+});

--- a/static/tool.css
+++ b/static/tool.css
@@ -1,3 +1,8 @@
 body {
     text-align: start;
 }
+
+#collapsible-menu.nojs {
+    display: flex;
+    flex-grow: 1;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,16 +14,22 @@
     <a href="#main" class="sr-only sr-only-focusable">Skip to main content</a>
     <nav class="navbar navbar-expand-sm navbar-dark bg-dark">
       <a href="{{ url_for('index') }}" class="navbar-brand">Wikidata Lexeme Forms</a>
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item"><a href="https://www.wikidata.org/wiki/Wikidata:Wikidata_Lexeme_Forms" class="nav-link">Documentation</a></li>
-        <li class="nav-item"><a href="//tools.wmflabs.org/" class="nav-link">Wikimedia Toolforge</a></li>
-        <li class="nav-item"><a href="https://phabricator.wikimedia.org/source/tool-lexeme-forms/" class="nav-link">Source code</a></li>
-      </ul>
-      {{ authentication_area() }}
+      <button hidden class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsible-menu" aria-controls="collapsible-menu" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div id="collapsible-menu" class="nojs">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item"><a href="https://www.wikidata.org/wiki/Wikidata:Wikidata_Lexeme_Forms" class="nav-link">Documentation</a></li>
+          <li class="nav-item"><a href="//tools.wmflabs.org/" class="nav-link">Wikimedia Toolforge</a></li>
+          <li class="nav-item"><a href="https://phabricator.wikimedia.org/source/tool-lexeme-forms/" class="nav-link">Source code</a></li>
+        </ul>
+        {{ authentication_area() }}
+      </div>
     </nav>
     <main id="main" {% block main_tag_attributes %}class="container mt-3"{% endblock main_tag_attributes %}>
       {% block main %}
       {% endblock main %}
     </main>
+    <script defer src="{{ url_for('static', filename='menu.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
To stop the navbar from wrapping onto multiple lines on narrow screens, this implements a collapsible navbar.