### PR TITLE
Add typing to most of tool’s source code

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ from mwapi_utils import T272319RetryingSession
 from parse_tpsv import parse_lexemes, FirstFieldNotLexemeIdError, FirstFieldLexemeIdError, WrongNumberOfFieldsError
 from templates import templates, templates_without_redirects, Template, TemplateForm
 from translations import translations
-from wikibase_types import Lemmas, Term
+from wikibase_types import LexemeLemmas, Term
 
 app = OrderedFlask(__name__)
 app.session_interface.serializer.register(TagOrderedMultiDict, index=0)
@@ -237,7 +237,7 @@ def term_span(term: Term) -> flask.Markup:
             flask.Markup(r'</span>'))
 
 @app.template_filter()
-def lemmas_spans(lemmas: Lemmas) -> flask.Markup:
+def lemmas_spans(lemmas: LexemeLemmas) -> flask.Markup:
     return flask.Markup(r'/').join(term_span(lemma)
                                    for lemma in lemmas.values())
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import babel
 import copy
 import decorator
 import flask
+from flask.typing import ResponseReturnValue as RRV
 import jinja2
 import json
 import mwapi  # type: ignore
@@ -143,7 +144,7 @@ def render_duplicates(
         in_bulk_mode: bool,
         template_name: Optional[str] = None,
         form_representations: list[str] = [],
-) -> flask.typing.ResponseValue:
+) -> RRV:
     return flask.render_template(
         'duplicates.html',
         duplicates=duplicates,
@@ -283,7 +284,7 @@ def language_name_with_code(language_code: str) -> flask.Markup:
             flask.Markup(r')</span>'))
 
 @app.route('/')
-def index() -> flask.typing.ResponseValue:
+def index() -> RRV:
     flask.g.interface_language_code = 'en'
     return flask.render_template(
         'index.html',
@@ -292,11 +293,11 @@ def index() -> flask.typing.ResponseValue:
     )
 
 @app.route('/template/<template_name>/', methods=['GET', 'POST'])
-def process_template(template_name: str) -> flask.typing.ResponseValue:
+def process_template(template_name: str) -> RRV:
     return process_template_advanced(template_name=template_name, advanced=False)
 
 @app.route('/template/<template_name>/advanced/', methods=['GET', 'POST'])
-def process_template_advanced(template_name: str, advanced: bool = True) -> flask.typing.ResponseValue:
+def process_template_advanced(template_name: str, advanced: bool = True) -> RRV:
     response = if_no_such_template_redirect(template_name)
     if response:
         return response
@@ -342,7 +343,7 @@ def process_template_advanced(template_name: str, advanced: bool = True) -> flas
         )
 
 @app.route('/template/<template_name>/bulk/', methods=['GET', 'POST'])
-def process_template_bulk(template_name: str) -> flask.typing.ResponseValue:
+def process_template_bulk(template_name: str) -> RRV:
     response = if_no_such_template_redirect(template_name)
     if response:
         return response
@@ -478,7 +479,7 @@ def process_template_bulk(template_name: str) -> flask.typing.ResponseValue:
         )
 
 @app.route('/template/<template_name>/edit/<lexeme_id>', methods=['GET', 'POST'])
-def process_template_edit(template_name: str, lexeme_id: str) -> flask.typing.ResponseValue:
+def process_template_edit(template_name: str, lexeme_id: str) -> RRV:
     response = if_no_such_template_redirect(template_name)
     if response:
         return response
@@ -556,7 +557,7 @@ def process_template_edit(template_name: str, lexeme_id: str) -> flask.typing.Re
         readonly=readonly,
     )
 
-def if_no_such_template_redirect(template_name: str) -> Optional[flask.typing.ResponseValue]:
+def if_no_such_template_redirect(template_name: str) -> Optional[RRV]:
     if template_name not in templates:
         return flask.render_template(
             'no-such-template.html',
@@ -583,7 +584,7 @@ def if_no_such_template_redirect(template_name: str) -> Optional[flask.typing.Re
         return None
 
 @app.route('/oauth/callback')
-def oauth_callback() -> flask.typing.ResponseValue:
+def oauth_callback() -> RRV:
     oauth_request_token = flask.session.pop('oauth_request_token', None)
     if oauth_request_token is None:
         return flask.render_template('error-oauth-callback.html',
@@ -596,7 +597,7 @@ def oauth_callback() -> flask.typing.ResponseValue:
     return flask.redirect(redirect_target or flask.url_for('index'))
 
 @app.route('/login')
-def login() -> flask.typing.ResponseValue:
+def login() -> RRV:
     if 'OAUTH' in app.config:
         (redirect, request_token) = mwoauth.initiate('https://www.wikidata.org/w/index.php', consumer_token, user_agent=user_agent)
         flask.session['oauth_request_token'] = dict(zip(request_token._fields, request_token))
@@ -606,7 +607,7 @@ def login() -> flask.typing.ResponseValue:
         return flask.redirect(flask.url_for('index'))
 
 @app.route('/logout')
-def logout() -> flask.typing.ResponseValue:
+def logout() -> RRV:
     flask.session.pop('oauth_access_token', None)
     return flask.redirect(flask.url_for('index'))
 
@@ -614,7 +615,7 @@ def if_has_duplicates_redirect(
         template: Template,
         advanced: bool,
         form_data: werkzeug.datastructures.MultiDict,
-) -> Optional[flask.typing.ResponseValue]:
+) -> Optional[RRV]:
     if 'no_duplicate' in form_data:
         return None
     if 'lexeme_id' in form_data and form_data['lexeme_id']:
@@ -676,7 +677,7 @@ def build_lemmas(
 
 @app.route('/api/v1/duplicates/<any(www,test):wiki>/<language_code>/<path:lemma>')
 @enableCORS
-def get_duplicates_api(wiki: str, language_code: str, lemma: str) -> flask.typing.ResponseValue:
+def get_duplicates_api(wiki: str, language_code: str, lemma: str) -> RRV:
     flask.g.interface_language_code = lang_lex2int(language_code)
     matches = get_duplicates(wiki, language_code, lemma)
     if not matches:
@@ -733,14 +734,14 @@ def get_duplicates(wiki: str, language_code: str, lemma: str) -> list[Duplicate]
 
 @app.route('/api/v1/no_duplicate/<language_code>')
 @app.template_global()
-def render_no_duplicate(language_code: str) -> flask.typing.ResponseValue:
+def render_no_duplicate(language_code: str) -> RRV:
     flask.g.interface_language_code = lang_lex2int(language_code)
     return flask.render_template(
         'no_duplicate.html',
     )
 
 @app.route('/api/v1/advanced_partial_forms_hint/<language_code>')
-def render_advanced_partial_forms_hint(language_code: str) -> flask.typing.ResponseValue:
+def render_advanced_partial_forms_hint(language_code: str) -> RRV:
     flask.g.interface_language_code = lang_lex2int(language_code)
     return flask.render_template(
         'advanced_partial_forms_hint.html',
@@ -748,7 +749,7 @@ def render_advanced_partial_forms_hint(language_code: str) -> flask.typing.Respo
 
 @app.route('/api/v1/match_template_to_lexeme/<any(www,test):wiki>/<lexeme_id>')
 @enableCORS
-def match_templates_to_lexeme_id(wiki: str, lexeme_id: str) -> flask.typing.ResponseValue:
+def match_templates_to_lexeme_id(wiki: str, lexeme_id: str) -> RRV:
     lexeme_data = get_lexeme_data(lexeme_id, wiki)
 
     return flask.jsonify({
@@ -758,7 +759,7 @@ def match_templates_to_lexeme_id(wiki: str, lexeme_id: str) -> flask.typing.Resp
 
 @app.route('/api/v1/match_template_to_lexeme/<any(www,test):wiki>/<lexeme_id>/<template_name>')
 @enableCORS
-def match_template_to_lexeme_id(wiki, lexeme_id, template_name):
+def match_template_to_lexeme_id(wiki: str, lexeme_id: str, template_name: str) -> RRV:
     template = templates.get(template_name)
     if not template:
         return 'no such template\n', 404
@@ -774,7 +775,7 @@ def match_template_to_lexeme_id(wiki, lexeme_id, template_name):
 
     if isinstance(template, list):
         return flask.jsonify([
-            match_template_to_lexeme_data(templates[replacement_name], lexeme_data)
+            match_template_to_lexeme_data(templates_without_redirects[replacement_name], lexeme_data)
             for replacement_name in template
         ])
 

--- a/app.py
+++ b/app.py
@@ -644,7 +644,7 @@ def find_duplicates(
     else:
         flask.abort(400)
 
-def get_lemma(form_data):
+def get_lemma(form_data: werkzeug.datastructures.MultiDict) -> Optional[str]:
     """Get the lemma for the lexeme from the given form data.
 
     The lemma is the first nonempty form representation variant.
@@ -660,7 +660,10 @@ def get_lemma(form_data):
                 return form_representation_variant
     return None
 
-def build_lemmas(template, form_data):
+def build_lemmas(
+        template: Template,
+        form_data: werkzeug.datastructures.MultiDict,
+) -> Optional[LexemeLemmas]:
     """Build the lemmas value for the given form data, if any.
 
     The value returned by this function can contain at most one lemma,
@@ -730,14 +733,14 @@ def get_duplicates(wiki: str, language_code: str, lemma: str) -> list[Duplicate]
 
 @app.route('/api/v1/no_duplicate/<language_code>')
 @app.template_global()
-def render_no_duplicate(language_code):
+def render_no_duplicate(language_code: str) -> flask.typing.ResponseValue:
     flask.g.interface_language_code = lang_lex2int(language_code)
     return flask.render_template(
         'no_duplicate.html',
     )
 
 @app.route('/api/v1/advanced_partial_forms_hint/<language_code>')
-def render_advanced_partial_forms_hint(language_code):
+def render_advanced_partial_forms_hint(language_code: str) -> flask.typing.ResponseValue:
     flask.g.interface_language_code = lang_lex2int(language_code)
     return flask.render_template(
         'advanced_partial_forms_hint.html',
@@ -745,7 +748,7 @@ def render_advanced_partial_forms_hint(language_code):
 
 @app.route('/api/v1/match_template_to_lexeme/<any(www,test):wiki>/<lexeme_id>')
 @enableCORS
-def match_templates_to_lexeme_id(wiki, lexeme_id):
+def match_templates_to_lexeme_id(wiki: str, lexeme_id: str) -> flask.typing.ResponseValue:
     lexeme_data = get_lexeme_data(lexeme_id, wiki)
 
     return flask.jsonify({

--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from language_names import autonym, label
 from matching import match_template_to_lexeme_data, match_lexeme_forms_to_template, match_template_entity_to_lexeme_entity
 from mwapi_utils import T272319RetryingSession
 from parse_tpsv import parse_lexemes, FirstFieldNotLexemeIdError, FirstFieldLexemeIdError, WrongNumberOfFieldsError
-from templates import templates, templates_without_redirects, Form, Template
+from templates import templates, templates_without_redirects, Template, TemplateForm
 from translations import translations
 from wikibase_types import Lemmas, Term
 
@@ -82,7 +82,7 @@ def denyFrame(response: werkzeug.Response) -> werkzeug.Response:
     return response
 
 @app.template_filter()
-def form2label(form: Form) -> flask.Markup:
+def form2label(form: TemplateForm) -> flask.Markup:
     ret = flask.Markup.escape(form['label'])
     if form.get('optional', False):
         ret += (flask.Markup(r'<span class="text-muted">') +
@@ -113,7 +113,7 @@ def form2input(context, form, first=False, readonly=False, template_language_cod
             flask.Markup(r'>') +
             flask.Markup.escape(suffix))
 
-def split_example(form: Form) -> Tuple[str, str, str]:
+def split_example(form: TemplateForm) -> Tuple[str, str, str]:
     example = form['example']
     match = re.match(r'^(.*)\[(.*)\](.*)$', example)
     if match:

--- a/matching.py
+++ b/matching.py
@@ -2,6 +2,7 @@ import copy
 from typing import cast, TypedDict, Union
 
 from templates import Template, TemplateForm
+from wikibase_types import Statement, Statements
 
 
 class MatchedTemplateForm(TemplateForm, total=False):
@@ -17,9 +18,9 @@ class MatchedTemplate(Template, total=False):
 class OverallMatch(TypedDict):
     language: bool
     lexical_category: bool
-    matched_statements: dict[str, list[dict]]
-    missing_statements: dict[str, list[dict]]
-    conflicting_statements: dict[str, list[dict]]
+    matched_statements: Statements
+    missing_statements: Statements
+    conflicting_statements: Statements
 
 
 # whether the presence of some statement for a property
@@ -67,10 +68,10 @@ def match_template_entity_to_lexeme_entity(  # may be template + lexeme or templ
         test: bool,
         template_entity: Union[Template, TemplateForm],
         lexeme_entity: dict,
-) -> tuple[dict[str, list[dict]], dict[str, list[dict]], dict[str, list[dict]]]:
-    matched_statements: dict[str, list[dict]] = {}
-    missing_statements: dict[str, list[dict]] = {}
-    conflicting_statements: dict[str, list[dict]] = {}
+) -> tuple[Statements, Statements, Statements]:
+    matched_statements: Statements = {}
+    missing_statements: Statements = {}
+    conflicting_statements: Statements = {}
 
     properties_exclusive_for_template_entity = properties_exclusive['test' if test else 'www']
     for property_id in template_entity.get('statements', {}):
@@ -96,7 +97,7 @@ def match_template_entity_to_lexeme_entity(  # may be template + lexeme or templ
     return matched_statements, missing_statements, conflicting_statements
 
 
-def match_statement(template_statement: dict, lexeme_statement: dict) -> bool:
+def match_statement(template_statement: Statement, lexeme_statement: Statement) -> bool:
     # so far, we only compare the main snak (ignoring qualifiers and references),
     # and only support entity ID values, because that’s all the templates use
     if lexeme_statement['mainsnak']['snaktype'] == 'value':

--- a/matching.py
+++ b/matching.py
@@ -2,17 +2,17 @@ import copy
 from typing import cast, TypedDict, Union
 
 from templates import Template, TemplateForm
-from wikibase_types import Statement, Statements
+from wikibase_types import Lexeme, LexemeForm, Statement, Statements
 
 
 class MatchedTemplateForm(TemplateForm, total=False):
-    lexeme_forms: list[dict]
+    lexeme_forms: list[LexemeForm]
 
 
 class MatchedTemplate(Template, total=False):
     # forms: list[MatchedTemplateForm]  # overwriting field is not allowed
-    ambiguous_lexeme_forms: list[dict]
-    unmatched_lexeme_forms: list[dict]
+    ambiguous_lexeme_forms: list[LexemeForm]
+    unmatched_lexeme_forms: list[LexemeForm]
 
 
 class OverallMatch(TypedDict):
@@ -50,7 +50,7 @@ properties_exclusive = {
 }
 
 
-def match_template_to_lexeme_data(template: Template, lexeme_data: dict) -> OverallMatch:
+def match_template_to_lexeme_data(template: Template, lexeme_data: Lexeme) -> OverallMatch:
     language_matches = template['language_item_id'] == lexeme_data['language']
     lexical_category_matches = template['lexical_category_item_id'] == lexeme_data['lexicalCategory']
     matched_statements, missing_statements, conflicting_statements = match_template_entity_to_lexeme_entity('test' in template, template, lexeme_data)
@@ -67,7 +67,7 @@ def match_template_to_lexeme_data(template: Template, lexeme_data: dict) -> Over
 def match_template_entity_to_lexeme_entity(  # may be template + lexeme or template form + lexeme form
         test: bool,
         template_entity: Union[Template, TemplateForm],
-        lexeme_entity: dict,
+        lexeme_entity: Union[Lexeme, LexemeForm],
 ) -> tuple[Statements, Statements, Statements]:
     matched_statements: Statements = {}
     missing_statements: Statements = {}
@@ -122,7 +122,7 @@ def match_lexeme_forms_to_template(lexeme_forms: list, template: Template) -> Ma
     return template
 
 
-def match_lexeme_form_to_template_forms(test: bool, lexeme_form: dict, template_forms: list[TemplateForm]) -> list[TemplateForm]:
+def match_lexeme_form_to_template_forms(test: bool, lexeme_form: LexemeForm, template_forms: list[TemplateForm]) -> list[TemplateForm]:
     best_template_forms = []
     best_matching_features = 0
     for template_form in template_forms:
@@ -138,7 +138,7 @@ def match_lexeme_form_to_template_forms(test: bool, lexeme_form: dict, template_
     return best_template_forms
 
 
-def match_lexeme_form_to_template_form(test: bool, lexeme_form: dict, template_form: TemplateForm) -> int:
+def match_lexeme_form_to_template_form(test: bool, lexeme_form: LexemeForm, template_form: TemplateForm) -> int:
     matching_features = 0
 
     for grammatical_feature_item_id in template_form['grammatical_features_item_ids']:

--- a/matching.py
+++ b/matching.py
@@ -1,15 +1,15 @@
 import copy
 from typing import cast, TypedDict, Union
 
-from templates import Form, Template
+from templates import Template, TemplateForm
 
 
-class MatchedForm(Form, total=False):
+class MatchedTemplateForm(TemplateForm, total=False):
     lexeme_forms: list[dict]
 
 
 class MatchedTemplate(Template, total=False):
-    # forms: list[MatchedForm]  # overwriting field is not allowed
+    # forms: list[MatchedTemplateForm]  # overwriting field is not allowed
     ambiguous_lexeme_forms: list[dict]
     unmatched_lexeme_forms: list[dict]
 
@@ -65,7 +65,7 @@ def match_template_to_lexeme_data(template: Template, lexeme_data: dict) -> Over
 
 def match_template_entity_to_lexeme_entity(  # may be template + lexeme or template form + lexeme form
         test: bool,
-        template_entity: Union[Template, Form],
+        template_entity: Union[Template, TemplateForm],
         lexeme_entity: dict,
 ) -> tuple[dict[str, list[dict]], dict[str, list[dict]], dict[str, list[dict]]]:
     matched_statements: dict[str, list[dict]] = {}
@@ -112,7 +112,7 @@ def match_lexeme_forms_to_template(lexeme_forms: list, template: Template) -> Ma
     for lexeme_form in lexeme_forms:
         best_template_forms = match_lexeme_form_to_template_forms('test' in template, lexeme_form, template['forms'])
         if len(best_template_forms) == 1:
-            best_template_form = cast(MatchedForm, best_template_forms[0])
+            best_template_form = cast(MatchedTemplateForm, best_template_forms[0])
             best_template_form.setdefault('lexeme_forms', []).append(lexeme_form)
         elif best_template_forms:
             template.setdefault('ambiguous_lexeme_forms', []).append(lexeme_form)
@@ -121,7 +121,7 @@ def match_lexeme_forms_to_template(lexeme_forms: list, template: Template) -> Ma
     return template
 
 
-def match_lexeme_form_to_template_forms(test: bool, lexeme_form: dict, template_forms: list[Form]) -> list[Form]:
+def match_lexeme_form_to_template_forms(test: bool, lexeme_form: dict, template_forms: list[TemplateForm]) -> list[TemplateForm]:
     best_template_forms = []
     best_matching_features = 0
     for template_form in template_forms:
@@ -137,7 +137,7 @@ def match_lexeme_form_to_template_forms(test: bool, lexeme_form: dict, template_
     return best_template_forms
 
 
-def match_lexeme_form_to_template_form(test: bool, lexeme_form: dict, template_form: Form) -> int:
+def match_lexeme_form_to_template_form(test: bool, lexeme_form: dict, template_form: TemplateForm) -> int:
     matching_features = 0
 
     for grammatical_feature_item_id in template_form['grammatical_features_item_ids']:
@@ -157,7 +157,7 @@ def match_lexeme_form_to_template_form(test: bool, lexeme_form: dict, template_f
     return matching_features
 
 
-def matchable_features(template_form: Form) -> int:
+def matchable_features(template_form: TemplateForm) -> int:
     features = len(template_form['grammatical_features_item_ids'])
     for property_id in template_form.get('statements', {}):
         features += len(template_form['statements'][property_id])

--- a/parse_tpsv.py
+++ b/parse_tpsv.py
@@ -4,8 +4,10 @@ import re
 from typing import List
 import werkzeug.datastructures
 
+from templates import Template
 
-def parse_lexemes(tpsv: str, template: dict) -> List[werkzeug.datastructures.MultiDict]:
+
+def parse_lexemes(tpsv: str, template: Template) -> List[werkzeug.datastructures.MultiDict]:
     lexemes = []
     for n, line in enumerate(tpsv.split('\n')):
         line = line.rstrip('\r')
@@ -15,7 +17,7 @@ def parse_lexemes(tpsv: str, template: dict) -> List[werkzeug.datastructures.Mul
     return lexemes
 
 
-def parse_lexeme(line: str, template: dict, line_number: int) -> werkzeug.datastructures.MultiDict:
+def parse_lexeme(line: str, template: Template, line_number: int) -> werkzeug.datastructures.MultiDict:
     fields = [field.strip() for field in line.replace('\t', '|').split('|')]
     if len(fields) == len(template['forms']) + 1:
         [lexeme_id, *form_representations] = fields

--- a/requirements.in
+++ b/requirements.in
@@ -8,9 +8,11 @@ mwoauth
 mypy
 pytest
 PyYAML
+requests
 requests_oauthlib
 toolforge ~= 4.2
 types-babel
 types-decorator
 types-PyYAML
+types-requests
 werkzeug >= 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,7 @@ pyyaml==6.0
     # via -r requirements.in
 requests==2.27.1
     # via
+    #   -r requirements.in
     #   mwapi
     #   mwoauth
     #   requests-oauthlib
@@ -94,6 +95,10 @@ types-pytz==2021.3.6
     # via types-babel
 types-pyyaml==6.0.5
     # via -r requirements.in
+types-requests==2.28.1
+    # via -r requirements.in
+types-urllib3==1.26.16
+    # via types-requests
 typing-extensions==4.1.1
     # via mypy
 urllib3==1.26.9

--- a/templates.py
+++ b/templates.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Optional, Set, TypedDict, Union
 
+from wikibase_types import Statement, Statements
+
 
 class CoreTemplateForm(TypedDict):
     label: str
@@ -31,10 +33,10 @@ MetaTemplate = TypedDict('MetaTemplate', {
 class Template(CoreTemplate, MetaTemplate, total=False):
     test: bool
     two_column_sections: bool
-    statements: dict
+    statements: Statements
 
 
-def statement(property_id: str, item_id: str) -> dict:
+def statement(property_id: str, item_id: str) -> Statement:
     return {
         'mainsnak': {
             'snaktype': 'value',
@@ -53,7 +55,7 @@ def statement(property_id: str, item_id: str) -> dict:
     }
 
 
-def statements(property_id: str, item_id: str) -> dict:
+def statements(property_id: str, item_id: str) -> Statements:
     return {
         property_id: [
             statement(property_id, item_id),

--- a/templates.py
+++ b/templates.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, Optional, Set, TypedDict, Union
 
 
-class CoreForm(TypedDict):
+class CoreTemplateForm(TypedDict):
     label: str
     example: str
     grammatical_features_item_ids: List[str]
 
-class Form(CoreForm, total=False):
+class TemplateForm(CoreTemplateForm, total=False):
     section_break: bool
     optional: bool
     grammatical_features_item_ids_optional: Set[str]
@@ -17,7 +17,7 @@ class CoreTemplate(TypedDict):
     language_item_id: str
     language_code: str
     lexical_category_item_id: str
-    forms: List[Form]
+    forms: List[TemplateForm]
 
 class Attribution(TypedDict):
     users: List[str]

--- a/test_matching.py
+++ b/test_matching.py
@@ -2,25 +2,6 @@ import matching
 import templates
 
 
-def make_statement(property_id: str, item_id: str) -> dict:
-    return {
-        'mainsnak': {
-            'snaktype': 'value',
-            'property': property_id,
-            'datatype': 'wikibase-item',
-            'datavalue': {
-                'type': 'wikibase-entityid',
-                'value': {
-                    'entity-type': 'item',
-                    'id': item_id,
-                },
-            },
-        },
-        'type': 'statement',
-        'rank': 'normal',
-    }
-
-
 lexeme_data_german_noun_neuter = {
     'lexicalCategory': 'Q1084',
     'language': 'Q188',
@@ -198,22 +179,22 @@ def test_match_lexeme_forms_to_template_with_optional_grammatical_features():
 def test_match_lexeme_form_to_template_forms():
     lexeme_form = {
         'grammaticalFeatures': ['Q1', 'Q2', 'Q3'],
-        'claims': {'P31': [make_statement('P31', 'Q4115189')]},
+        'claims': templates.statements('P31', 'Q4115189'),
     }
     template_form_missing_grammatical_feature = {
         'grammatical_features_item_ids': ['Q1', 'Q2', 'Q3', 'Q4'],
-        'statements': {'P31': [make_statement('P31', 'Q4115189')]},
+        'statements': templates.statements('P31', 'Q4115189'),
     }
     template_form_missing_statement = {
         'grammatical_features_item_ids': ['Q1', 'Q2'],
-        'statements': {'P31': [make_statement('P31', 'Q4115189'), make_statement('P31', 'Q13406268')]},
+        'statements': {'P31': [templates.statement('P31', 'Q4115189'), templates.statement('P31', 'Q13406268')]},
     }
     template_form_match_two_grammatical_features_no_statement = {
         'grammatical_features_item_ids': ['Q1', 'Q2'],
     }
     template_form_match_one_grammatical_feature_one_statement = {
         'grammatical_features_item_ids': ['Q1'],
-        'statements': {'P31': [make_statement('P31', 'Q4115189')]},
+        'statements': templates.statements('P31', 'Q4115189'),
     }
     template_form_match_two_grammatical_features_one_optional = {
         'grammatical_features_item_ids': ['Q1', 'Q2', 'Q4'],
@@ -272,18 +253,18 @@ def test_match_lexeme_form_to_template_form_missing_statement():
     lexeme_form = {'grammaticalFeatures': ['Q1']}
     template_form = {
         'grammatical_features_item_ids': ['Q1'],
-        'statements': {'P31': [make_statement('P31', 'Q4115189')]},
+        'statements': templates.statements('P31', 'Q4115189'),
     }
     assert matching.match_lexeme_form_to_template_form(False, lexeme_form, template_form) == 0
 
 def test_match_lexeme_form_to_template_form_conflicting_statement():
     lexeme_form = {
         'grammaticalFeatures': ['Q1'],
-        'claims': {'P5185': [make_statement('P5185', 'Q4115189'), make_statement('P5185', 'Q13406268')]},
+        'claims': {'P5185': [templates.statement('P5185', 'Q4115189'), templates.statement('P5185', 'Q13406268')]},
     }
     template_form = {
         'grammatical_features_item_ids': ['Q1'],
-        'statements': {'P5185': [make_statement('P5185', 'Q4115189')]},
+        'statements': templates.statements('P5185', 'Q4115189'),
     }
     assert matching.match_lexeme_form_to_template_form(False, lexeme_form, template_form) == 0
 
@@ -291,15 +272,15 @@ def test_match_lexeme_form_to_template_form_counts_grammatical_features_and_stat
     lexeme_form = {
         'grammaticalFeatures': ['Q1', 'Q2', 'Q3', 'Q4'],
         'claims': {
-            'P31': [make_statement('P31', 'Q4115189'), make_statement('P31', 'Q13406268')],
-            'P5185': [make_statement('P5185', 'Q4115189')],
+            'P31': [templates.statement('P31', 'Q4115189'), templates.statement('P31', 'Q13406268')],
+            'P5185': [templates.statement('P5185', 'Q4115189')],
         },
     }
     template_form = {
         'grammatical_features_item_ids': ['Q1', 'Q2'],
         'statements': {
-            'P31': [make_statement('P31', 'Q4115189')],
-            'P5185': [make_statement('P5185', 'Q4115189')],
+            'P31': [templates.statement('P31', 'Q4115189')],
+            'P5185': [templates.statement('P5185', 'Q4115189')],
         },
     }
     assert matching.match_lexeme_form_to_template_form(False, lexeme_form, template_form) == 4

--- a/wikibase_types.py
+++ b/wikibase_types.py
@@ -6,9 +6,6 @@ class Term(TypedDict):
     value: str
 
 
-Lemmas = dict[str, Term]
-
-
 WikibaseEntityIdDataValueValue = TypedDict('WikibaseEntityIdDataValueValue', {
     'entity-type': Literal['item'],
     'id': str,
@@ -36,3 +33,33 @@ class Statement(TypedDict):
 
 StatementGroup = list[Statement]
 Statements = dict[str, StatementGroup]
+
+
+LexemeFormRepresentations = dict[str, Term]
+LexemeLemmas = dict[str, Term]
+
+
+class CoreLexemeForm(TypedDict):
+    representations: LexemeFormRepresentations
+    grammaticalFeatures: list[str]
+    claims: Statements
+
+
+class LexemeForm(CoreLexemeForm, total=False):
+    add: Literal['']  # only needed when creating
+    remove: Literal['']  # only needed when editing
+
+
+class CoreLexeme(TypedDict):
+    type: Literal['lexeme']
+    lemmas: LexemeLemmas
+    language: str
+    lexicalCategory: str
+    claims: Statements
+    forms: list[LexemeForm]
+    # senses not used in this tool
+
+
+class Lexeme(CoreLexeme, total=False):
+    id: str  # only needed when editing
+    base_revision_id: str  # only needed when editing

--- a/wikibase_types.py
+++ b/wikibase_types.py
@@ -1,9 +1,13 @@
 from typing import Literal, TypedDict
 
 
-class Term(TypedDict):
+class CoreTerm(TypedDict):
     language: str
     value: str
+
+
+class Term(CoreTerm, total=False):
+    remove: Literal['']  # only needed when editing
 
 
 WikibaseEntityIdDataValueValue = TypedDict('WikibaseEntityIdDataValueValue', {
@@ -48,6 +52,7 @@ class CoreLexemeForm(TypedDict):
 class LexemeForm(CoreLexemeForm, total=False):
     add: Literal['']  # only needed when creating
     remove: Literal['']  # only needed when editing
+    id: Literal['']  # only present when editing
 
 
 class CoreLexeme(TypedDict):

--- a/wikibase_types.py
+++ b/wikibase_types.py
@@ -63,3 +63,4 @@ class CoreLexeme(TypedDict):
 class Lexeme(CoreLexeme, total=False):
     id: str  # only needed when editing
     base_revision_id: str  # only needed when editing
+    lastrevid: int  # only available when data returned by API

--- a/wikibase_types.py
+++ b/wikibase_types.py
@@ -1,0 +1,9 @@
+from typing import TypedDict
+
+
+class Term(TypedDict):
+    language: str
+    value: str
+
+
+Lemmas = dict[str, Term]

--- a/wikibase_types.py
+++ b/wikibase_types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 
 class Term(TypedDict):
@@ -7,3 +7,32 @@ class Term(TypedDict):
 
 
 Lemmas = dict[str, Term]
+
+
+WikibaseEntityIdDataValueValue = TypedDict('WikibaseEntityIdDataValueValue', {
+    'entity-type': Literal['item'],
+    'id': str,
+})
+
+
+class WikibaseEntityIdDataValue(TypedDict):
+    type: Literal['wikibase-entityid']
+    value: WikibaseEntityIdDataValueValue
+
+
+class Snak(TypedDict):
+    snaktype: Literal['value']  # other snak types not used in this tool
+    property: str
+    datatype: Literal['wikibase-item']  # other data types not used in this tool
+    datavalue: WikibaseEntityIdDataValue
+
+
+class Statement(TypedDict):
+    mainsnak: Snak
+    # qualifiers and references not used in this tool
+    type: Literal['statement']
+    rank: Literal['normal']  # other ranks not used in this tool
+
+
+StatementGroup = list[Statement]
+Statements = dict[str, StatementGroup]


### PR DESCRIPTION
This adds typing to most of the tool’s source code that didn’t have types yet, particularly `app.py`, and also refines types of some functions that were already typed, mainly by replacing `dict` with proper typed dicts for Wikibase types (collected in `wikibase_types.py`). This puts the tool on a more solid technical basis to prepare for upcoming changes to the data model (to support [Punjabi templates](https://www.wikidata.org/wiki/Topic:Wz65gp5zqyd09atk), we will likely allow form labels and examples to be dicts in addition to strings).